### PR TITLE
Ranking: Merge First and Last Name columns into a Name column

### DIFF
--- a/cmsranking/static/Scoreboard.js
+++ b/cmsranking/static/Scoreboard.js
@@ -154,7 +154,7 @@ var Scoreboard = new function () {
 <col class=\"sel\"/> \
 <col class=\"rank\"/> \
 <col class=\"f_name\"/> <col/><col/><col/><col/><col/><col/><col/><col/><col/> \
-<col class=\"l_name\"/> <col/><col/><col/><col/><col/><col/><col/><col/><col/> \
+<col/><col/><col/><col/><col/><col/> \
 <col class=\"team\"/>";
 
         var contests = DataStore.contest_list;
@@ -188,8 +188,7 @@ var Scoreboard = new function () {
 <tr> \
     <th class=\"sel\"></th> \
     <th class=\"rank\">Rank</th> \
-    <th colspan=\"10\" class=\"f_name\">First Name</th> \
-    <th colspan=\"10\" class=\"l_name\">Last Name</th> \
+    <th colspan=\"16\" class=\"f_name\">Name</th> \
     <th class=\"team\">Team</th>";
 
         var contests = DataStore.contest_list;
@@ -235,8 +234,7 @@ var Scoreboard = new function () {
 <tr class=\"user" + (user["selected"] > 0 ? " selected color" + user["selected"] : "") + "\" data-user=\"" + user["key"] + "\"> \
     <td class=\"sel\"></td> \
     <td class=\"rank\">" + user["rank"] + "</td> \
-    <td colspan=\"10\" class=\"f_name\">" + escapeHTML(user["f_name"]) + "</td> \
-    <td colspan=\"10\" class=\"l_name\">" + escapeHTML(user["l_name"]) + "</td>";
+    <td colspan=\"16\" class=\"f_name\">" + escapeHTML(user["f_name"]) + " " + escapeHTML(user["l_name"]) + "</td>";
 
         if (user['team']) {
             result += " \
@@ -403,8 +401,7 @@ var Scoreboard = new function () {
         delete old_user["row"];
         delete old_user["index"];
 
-        $row.children("td.f_name").text(user["f_name"]);
-        $row.children("td.l_name").text(user["l_name"]);
+        $row.children("td.f_name").text(user["f_name"] + " " + user["l_name"]);
 
         $row.children(".team").text(user['key']);
         if (user["team"]) {


### PR DESCRIPTION
As the results page on the official IOI Stats website shows contestant names without distinguishing first and last names (e.g. https://stats.ioinformatics.org/results/2022), I think it's better for the CMS ranking page to also show them similarly.